### PR TITLE
feat: add iot netty module for device communication

### DIFF
--- a/jeecg-boot/jeecg-boot-module/jeecg-module-iot/pom.xml
+++ b/jeecg-boot/jeecg-boot-module/jeecg-module-iot/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>jeecg-boot-module</artifactId>
+        <groupId>org.jeecgframework.boot3</groupId>
+        <version>3.8.3</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jeecg-module-iot</artifactId>
+
+    <properties>
+        <netty.version>4.1.109.Final</netty.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jeecgframework.boot3</groupId>
+            <artifactId>jeecg-boot-base-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jeecg-boot/jeecg-boot-module/jeecg-module-iot/src/main/java/org/jeecg/modules/iot/config/IotNettyAutoConfiguration.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-module-iot/src/main/java/org/jeecg/modules/iot/config/IotNettyAutoConfiguration.java
@@ -1,0 +1,33 @@
+package org.jeecg.modules.iot.config;
+
+import org.jeecg.modules.iot.server.IotNettyServer;
+import org.jeecg.modules.iot.server.IotNettyServerProperties;
+import org.jeecg.modules.iot.service.DefaultDeviceMessageProcessor;
+import org.jeecg.modules.iot.service.DeviceMessageProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Auto configuration that wires and starts the Netty server for IoT device communication.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(IotNettyServer.class)
+@EnableConfigurationProperties(IotNettyServerProperties.class)
+@ConditionalOnProperty(prefix = "jeecg.iot.netty", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class IotNettyAutoConfiguration {
+
+    @Bean(initMethod = "start", destroyMethod = "stop")
+    public IotNettyServer iotNettyServer(IotNettyServerProperties properties, DeviceMessageProcessor deviceMessageProcessor) {
+        return new IotNettyServer(properties, deviceMessageProcessor);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public DeviceMessageProcessor deviceMessageProcessor() {
+        return new DefaultDeviceMessageProcessor();
+    }
+}

--- a/jeecg-boot/jeecg-boot-module/jeecg-module-iot/src/main/java/org/jeecg/modules/iot/handler/DeviceMessageHandler.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-module-iot/src/main/java/org/jeecg/modules/iot/handler/DeviceMessageHandler.java
@@ -1,0 +1,84 @@
+package org.jeecg.modules.iot.handler;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.CharsetUtil;
+import org.jeecg.modules.iot.model.DeviceMessage;
+import org.jeecg.modules.iot.model.DeviceResponse;
+import org.jeecg.modules.iot.service.DeviceMessageProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Netty channel handler that converts HTTP requests into {@link DeviceMessage} instances.
+ */
+public class DeviceMessageHandler extends io.netty.channel.SimpleChannelInboundHandler<FullHttpRequest> {
+
+    private static final Logger log = LoggerFactory.getLogger(DeviceMessageHandler.class);
+
+    private final DeviceMessageProcessor messageProcessor;
+
+    public DeviceMessageHandler(DeviceMessageProcessor messageProcessor) {
+        this.messageProcessor = messageProcessor;
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest msg) {
+        DeviceMessage message = DeviceMessage.builder()
+                .uri(msg.uri())
+                .method(msg.method().name())
+                .headers(extractHeaders(msg))
+                .payload(msg.content().toString(CharsetUtil.UTF_8))
+                .build();
+        DeviceResponse response = messageProcessor.process(message);
+        FullHttpResponse httpResponse = toHttpResponse(response);
+        boolean keepAlive = io.netty.handler.codec.http.HttpUtil.isKeepAlive(msg);
+        if (keepAlive) {
+            httpResponse.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
+            ctx.writeAndFlush(httpResponse);
+        } else {
+            ctx.writeAndFlush(httpResponse).addListener(ChannelFutureListener.CLOSE);
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        log.error("Unexpected error while handling device message", cause);
+        FullHttpResponse response = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1,
+                HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                Unpooled.copiedBuffer("Internal Server Error", CharsetUtil.UTF_8)
+        );
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=UTF-8");
+        ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+    }
+
+    private Map<String, String> extractHeaders(FullHttpRequest request) {
+        Map<String, String> headers = new HashMap<>();
+        request.headers().forEach(entry -> headers.put(entry.getKey(), entry.getValue()));
+        return headers;
+    }
+
+    private FullHttpResponse toHttpResponse(DeviceResponse response) {
+        FullHttpResponse httpResponse = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1,
+                HttpResponseStatus.valueOf(response.getStatusCode()),
+                Unpooled.copiedBuffer(response.getBody(), response.getCharset())
+        );
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json; charset=" + response.getCharset().name());
+        response.getHeaders().forEach(httpResponse.headers()::set);
+        httpResponse.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, httpResponse.content().readableBytes());
+        return httpResponse;
+    }
+}

--- a/jeecg-boot/jeecg-boot-module/jeecg-module-iot/src/main/java/org/jeecg/modules/iot/model/DeviceMessage.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-module-iot/src/main/java/org/jeecg/modules/iot/model/DeviceMessage.java
@@ -1,0 +1,76 @@
+package org.jeecg.modules.iot.model;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Represents a message sent by a connected device through the HTTP based private protocol.
+ */
+public class DeviceMessage {
+
+    private final String uri;
+    private final String method;
+    private final Map<String, String> headers;
+    private final String payload;
+
+    private DeviceMessage(Builder builder) {
+        this.uri = builder.uri;
+        this.method = builder.method;
+        this.headers = builder.headers == null ? Collections.emptyMap() : Collections.unmodifiableMap(builder.headers);
+        this.payload = builder.payload;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String uri;
+        private String method;
+        private Map<String, String> headers;
+        private String payload;
+
+        private Builder() {
+        }
+
+        public Builder uri(String uri) {
+            this.uri = uri;
+            return this;
+        }
+
+        public Builder method(String method) {
+            this.method = method;
+            return this;
+        }
+
+        public Builder headers(Map<String, String> headers) {
+            this.headers = headers;
+            return this;
+        }
+
+        public Builder payload(String payload) {
+            this.payload = payload;
+            return this;
+        }
+
+        public DeviceMessage build() {
+            return new DeviceMessage(this);
+        }
+    }
+}

--- a/jeecg-boot/jeecg-boot-module/jeecg-module-iot/src/main/java/org/jeecg/modules/iot/model/DeviceResponse.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-module-iot/src/main/java/org/jeecg/modules/iot/model/DeviceResponse.java
@@ -1,0 +1,78 @@
+package org.jeecg.modules.iot.model;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Simple response model returned to devices after processing a message.
+ */
+public class DeviceResponse {
+
+    private final int statusCode;
+    private final Map<String, String> headers;
+    private final String body;
+    private final Charset charset;
+
+    private DeviceResponse(Builder builder) {
+        this.statusCode = builder.statusCode;
+        this.headers = builder.headers == null ? Collections.emptyMap() : Collections.unmodifiableMap(builder.headers);
+        this.body = builder.body == null ? "" : builder.body;
+        this.charset = builder.charset == null ? StandardCharsets.UTF_8 : builder.charset;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public Charset getCharset() {
+        return charset;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private int statusCode = 200;
+        private Map<String, String> headers;
+        private String body;
+        private Charset charset;
+
+        private Builder() {
+        }
+
+        public Builder statusCode(int statusCode) {
+            this.statusCode = statusCode;
+            return this;
+        }
+
+        public Builder headers(Map<String, String> headers) {
+            this.headers = headers;
+            return this;
+        }
+
+        public Builder body(String body) {
+            this.body = body;
+            return this;
+        }
+
+        public Builder charset(Charset charset) {
+            this.charset = charset;
+            return this;
+        }
+
+        public DeviceResponse build() {
+            return new DeviceResponse(this);
+        }
+    }
+}

--- a/jeecg-boot/jeecg-boot-module/jeecg-module-iot/src/main/java/org/jeecg/modules/iot/server/IotNettyServer.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-module-iot/src/main/java/org/jeecg/modules/iot/server/IotNettyServer.java
@@ -1,0 +1,92 @@
+package org.jeecg.modules.iot.server;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import org.jeecg.modules.iot.handler.DeviceMessageHandler;
+import org.jeecg.modules.iot.service.DeviceMessageProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Netty server that receives HTTP requests from the IoT devices and hands them over to the configured processor.
+ */
+public class IotNettyServer {
+
+    private static final Logger log = LoggerFactory.getLogger(IotNettyServer.class);
+
+    private final IotNettyServerProperties properties;
+    private final DeviceMessageProcessor messageProcessor;
+
+    private EventLoopGroup bossGroup;
+    private EventLoopGroup workerGroup;
+    private Channel serverChannel;
+
+    public IotNettyServer(IotNettyServerProperties properties, DeviceMessageProcessor messageProcessor) {
+        this.properties = properties;
+        this.messageProcessor = messageProcessor;
+    }
+
+    public synchronized void start() throws InterruptedException {
+        if (!properties.isEnabled()) {
+            log.info("IoT Netty server is disabled via configuration");
+            return;
+        }
+        if (serverChannel != null && serverChannel.isActive()) {
+            log.debug("IoT Netty server already started");
+            return;
+        }
+        bossGroup = properties.getBossThreads() > 0 ? new NioEventLoopGroup(properties.getBossThreads()) : new NioEventLoopGroup();
+        workerGroup = properties.getWorkerThreads() > 0 ? new NioEventLoopGroup(properties.getWorkerThreads()) : new NioEventLoopGroup();
+
+        ServerBootstrap bootstrap = new ServerBootstrap();
+        bootstrap.group(bossGroup, workerGroup)
+                .channel(NioServerSocketChannel.class)
+                .option(ChannelOption.SO_BACKLOG, 128)
+                .childOption(ChannelOption.SO_KEEPALIVE, true)
+                .childHandler(new ChannelInitializer<SocketChannel>() {
+                    @Override
+                    protected void initChannel(SocketChannel ch) {
+                        ch.pipeline()
+                                .addLast(new HttpServerCodec())
+                                .addLast(new HttpObjectAggregator(1024 * 1024))
+                                .addLast(new ReadTimeoutHandler(60, TimeUnit.SECONDS))
+                                .addLast(new DeviceMessageHandler(messageProcessor));
+                    }
+                });
+
+        ChannelFuture channelFuture = bootstrap.bind(properties.getPort()).sync();
+        serverChannel = channelFuture.channel();
+        log.info("IoT Netty server started on port {}", properties.getPort());
+    }
+
+    public synchronized void stop() {
+        if (serverChannel != null) {
+            try {
+                serverChannel.close().syncUninterruptibly();
+            } finally {
+                serverChannel = null;
+            }
+        }
+        if (workerGroup != null) {
+            workerGroup.shutdownGracefully();
+            workerGroup = null;
+        }
+        if (bossGroup != null) {
+            bossGroup.shutdownGracefully();
+            bossGroup = null;
+        }
+        log.info("IoT Netty server stopped");
+    }
+}

--- a/jeecg-boot/jeecg-boot-module/jeecg-module-iot/src/main/java/org/jeecg/modules/iot/server/IotNettyServerProperties.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-module-iot/src/main/java/org/jeecg/modules/iot/server/IotNettyServerProperties.java
@@ -1,0 +1,62 @@
+package org.jeecg.modules.iot.server;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the IoT Netty server.
+ */
+@ConfigurationProperties(prefix = "jeecg.iot.netty")
+public class IotNettyServerProperties {
+
+    /**
+     * Whether the server should start automatically.
+     */
+    private boolean enabled = true;
+
+    /**
+     * Port used by the Netty HTTP server.
+     */
+    private int port = 9090;
+
+    /**
+     * Number of boss threads.
+     */
+    private int bossThreads = 1;
+
+    /**
+     * Number of worker threads.
+     */
+    private int workerThreads = 0;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public int getBossThreads() {
+        return bossThreads;
+    }
+
+    public void setBossThreads(int bossThreads) {
+        this.bossThreads = bossThreads;
+    }
+
+    public int getWorkerThreads() {
+        return workerThreads;
+    }
+
+    public void setWorkerThreads(int workerThreads) {
+        this.workerThreads = workerThreads;
+    }
+}

--- a/jeecg-boot/jeecg-boot-module/jeecg-module-iot/src/main/java/org/jeecg/modules/iot/service/DefaultDeviceMessageProcessor.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-module-iot/src/main/java/org/jeecg/modules/iot/service/DefaultDeviceMessageProcessor.java
@@ -1,0 +1,43 @@
+package org.jeecg.modules.iot.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jeecg.modules.iot.model.DeviceMessage;
+import org.jeecg.modules.iot.model.DeviceResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Default implementation that simply acknowledges the device payload and echoes the content.
+ * This can be replaced with a project specific processor bean.
+ */
+public class DefaultDeviceMessageProcessor implements DeviceMessageProcessor {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultDeviceMessageProcessor.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Override
+    public DeviceResponse process(DeviceMessage message) {
+        log.info("Received device message: uri={}, method={}, payload={}", message.getUri(), message.getMethod(), message.getPayload());
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("status", "OK");
+        responseBody.put("receivedUri", message.getUri());
+        responseBody.put("receivedMethod", message.getMethod());
+        responseBody.put("receivedPayload", message.getPayload());
+        try {
+            String body = OBJECT_MAPPER.writeValueAsString(responseBody);
+            return DeviceResponse.builder()
+                    .statusCode(200)
+                    .body(body)
+                    .build();
+        } catch (Exception e) {
+            log.error("Failed to serialize response for device message", e);
+            return DeviceResponse.builder()
+                    .statusCode(500)
+                    .body("{\"status\":\"ERROR\"}")
+                    .build();
+        }
+    }
+}

--- a/jeecg-boot/jeecg-boot-module/jeecg-module-iot/src/main/java/org/jeecg/modules/iot/service/DeviceMessageProcessor.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-module-iot/src/main/java/org/jeecg/modules/iot/service/DeviceMessageProcessor.java
@@ -1,0 +1,18 @@
+package org.jeecg.modules.iot.service;
+
+import org.jeecg.modules.iot.model.DeviceMessage;
+import org.jeecg.modules.iot.model.DeviceResponse;
+
+/**
+ * Strategy interface responsible for converting inbound device messages into responses.
+ */
+public interface DeviceMessageProcessor {
+
+    /**
+     * Process the inbound device message and return a response that will be sent to the device.
+     *
+     * @param message inbound message
+     * @return response to send back to the device
+     */
+    DeviceResponse process(DeviceMessage message);
+}

--- a/jeecg-boot/jeecg-boot-module/jeecg-module-iot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/jeecg-boot/jeecg-boot-module/jeecg-module-iot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.jeecg.modules.iot.config.IotNettyAutoConfiguration

--- a/jeecg-boot/jeecg-boot-module/pom.xml
+++ b/jeecg-boot/jeecg-boot-module/pom.xml
@@ -15,6 +15,7 @@
     <modules>
         <module>jeecg-module-demo</module>
         <module>jeecg-boot-module-airag</module>
+        <module>jeecg-module-iot</module>
     </modules>
 
 


### PR DESCRIPTION
## Summary
- add the jeecg-module-iot submodule to the jeecg-boot-module aggregator
- implement a Netty-based HTTP server, handler, models, and service contracts to process device-initiated messages
- provide Spring Boot auto-configuration and properties to wire and control the Netty server

## Testing
- mvn -pl jeecg-boot-module/jeecg-module-iot -am -DskipTests package *(fails: remote repository returned 403 when downloading Spring Boot parent)*

------
https://chatgpt.com/codex/tasks/task_e_68db4c7db69c8324900760b866ed5fc8